### PR TITLE
Update manifest.json to be compatible with Mozilla

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -14,5 +14,11 @@
       "run_at": "document_end"
    } ],
    "permissions": [ ],
-   "host_permissions": [ "https://*.j-archive.com/showgame*" ]
+   "host_permissions": [ "https://*.j-archive.com/showgame*" ],
+   "browser_specific_settings": {
+         "gecko": {
+         "id": "j-play@opencoder.net",
+         "strict_min_version": "109.0"
+      }
+   }
 }


### PR DESCRIPTION
If you are interested in also [publishing your j-play extension for Firefox](https://extensionworkshop.com/documentation/publish/submitting-an-add-on/), it's only a matter of submitting the same source code after a one-time code update.

Chrome extensions are [generally compatible with Firefox](https://extensionworkshop.com/documentation/develop/porting-a-google-chrome-extension/), with [a minor adjustment to the manifest](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings).

I was able to generate a [valid and signed .xpi extension](https://www.sendspace.com/file/3wuwic) from the existing source code and it does appear to function correctly, so that's all it should take. 👍